### PR TITLE
SCRUM-172: kishax-apiをECSでバックエンドで動かす

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,27 +170,19 @@ status-services: ## ECSサービスステータスを確認
 
 .PHONY: restart-discord-bot
 restart-discord-bot: ## Discord Botサービスを再起動 (force-new-deployment)
-	@echo "🔄 Discord Botサービスを再起動中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-discord-bot-service-v2 --force-new-deployment --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Discord Botサービスの再起動を要求しました (新しいタスクで再開)"
+	@scripts/ecs-service.sh restart kishax-discord-bot-service-v2
 
 .PHONY: restart-gather-bot
 restart-gather-bot: ## Gather Botサービスを再起動 (force-new-deployment)
-	@echo "🔄 Gather Botサービスを再起動中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-gather-bot-service-v2 --force-new-deployment --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Gather Botサービスの再起動を要求しました (新しいタスクで再開)"
+	@scripts/ecs-service.sh restart kishax-gather-bot-service-v2
 
 .PHONY: restart-web
 restart-web: ## Webサービスを再起動 (force-new-deployment)
-	@echo "🔄 Webサービスを再起動中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-web-service-v2 --force-new-deployment --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Webサービスの再起動を要求しました (新しいタスクで再開)"
+	@scripts/ecs-service.sh restart kishax-web-service-v2
 
 .PHONY: restart-auth
 restart-auth: ## Authサービスを再起動 (force-new-deployment)
-	@echo "🔄 Authサービスを再起動中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-auth-service-v2 --force-new-deployment --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Authサービスの再起動を要求しました (新しいタスクで再開)"
+	@scripts/ecs-service.sh restart kishax-auth-service-v2
 
 .PHONY: restart-all-services
 restart-all-services: restart-discord-bot restart-gather-bot restart-web restart-auth ## 全ECSサービスを再起動 (force-new-deployment)
@@ -202,58 +194,50 @@ restart-all-services: restart-discord-bot restart-gather-bot restart-web restart
 
 .PHONY: enable-discord-bot
 enable-discord-bot: ## Discord Botサービスを有効化 (desired-count=1)
-	@echo "🟢 Discord Botサービスを有効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-discord-bot-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Discord Botサービスを有効化しました"
+	@scripts/ecs-service.sh enable kishax-discord-bot-service-v2
 
 .PHONY: enable-gather-bot
 enable-gather-bot: ## Gather Botサービスを有効化 (desired-count=1)
-	@echo "🟢 Gather Botサービスを有効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-gather-bot-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Gather Botサービスを有効化しました"
+	@scripts/ecs-service.sh enable kishax-gather-bot-service-v2
 
 .PHONY: enable-web
 enable-web: ## Webサービスを有効化 (desired-count=1)
-	@echo "🟢 Webサービスを有効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-web-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Webサービスを有効化しました"
+	@scripts/ecs-service.sh enable kishax-web-service-v2
 
 .PHONY: enable-auth
 enable-auth: ## Authサービスを有効化 (desired-count=1)
-	@echo "🟢 Authサービスを有効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-auth-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Authサービスを有効化しました"
+	@scripts/ecs-service.sh enable kishax-auth-service-v2
+
+.PHONY: enable-api
+enable-api: ## APIサービスを有効化 (desired-count=1)
+	@scripts/ecs-service.sh enable kishax-api-service-v2
 
 .PHONY: enable-all-services
-enable-all-services: enable-discord-bot enable-gather-bot enable-web enable-auth ## 全ECSサービスを有効化
+enable-all-services: enable-discord-bot enable-gather-bot enable-web enable-auth enable-api ## 全ECSサービスを有効化
 	@echo "✅ 全サービスの有効化を完了しました"
 
 .PHONY: disable-discord-bot
 disable-discord-bot: ## Discord Botサービスを無効化 (desired-count=0)
-	@echo "🔴 Discord Botサービスを無効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-discord-bot-service-v2 --desired-count 0 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Discord Botサービスを無効化しました"
+	@scripts/ecs-service.sh disable kishax-discord-bot-service-v2
 
 .PHONY: disable-gather-bot
 disable-gather-bot: ## Gather Botサービスを無効化 (desired-count=0)
-	@echo "🔴 Gather Botサービスを無効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-gather-bot-service-v2 --desired-count 0 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Gather Botサービスを無効化しました"
+	@scripts/ecs-service.sh disable kishax-gather-bot-service-v2
 
 .PHONY: disable-web
 disable-web: ## Webサービスを無効化 (desired-count=0)
-	@echo "🔴 Webサービスを無効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-web-service-v2 --desired-count 0 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Webサービスを無効化しました"
+	@scripts/ecs-service.sh disable kishax-web-service-v2
 
 .PHONY: disable-auth
 disable-auth: ## Authサービスを無効化 (desired-count=0)
-	@echo "🔴 Authサービスを無効化中..."
-	@aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-auth-service-v2 --desired-count 0 --profile $(AWS_PROFILE) > /dev/null
-	@echo "✅ Authサービスを無効化しました"
+	@scripts/ecs-service.sh disable kishax-auth-service-v2
+
+.PHONY: disable-api
+disable-api: ## APIサービスを無効化 (desired-count=0)
+	@scripts/ecs-service.sh disable kishax-api-service-v2
 
 .PHONY: disable-all-services
-disable-all-services: disable-discord-bot disable-gather-bot disable-web disable-auth ## 全ECSサービスを無効化
+disable-all-services: disable-discord-bot disable-gather-bot disable-web disable-auth disable-api ## 全ECSサービスを無効化
 	@echo "✅ 全サービスの無効化を完了しました"
 
 # =============================================================================
@@ -262,47 +246,19 @@ disable-all-services: disable-discord-bot disable-gather-bot disable-web disable
 
 .PHONY: start-discord-bot
 start-discord-bot: ## Discord Bot停止中サービスを開始
-	@echo "▶️ Discord Botサービスを開始中..."
-	@CURRENT_COUNT=$$(aws ecs describe-services --cluster kishax-infrastructure-cluster --services kishax-discord-bot-service-v2 --profile $(AWS_PROFILE) --query "services[0].desiredCount" --output text); \
-	if [ "$$CURRENT_COUNT" = "0" ]; then \
-		aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-discord-bot-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Discord Botサービスを開始しました"; \
-	else \
-		echo "ℹ️ Discord Botサービスは既に実行中です (desired-count=$$CURRENT_COUNT)"; \
-	fi
+	@scripts/ecs-service.sh start kishax-discord-bot-service-v2
 
 .PHONY: start-gather-bot
 start-gather-bot: ## Gather Bot停止中サービスを開始
-	@echo "▶️ Gather Botサービスを開始中..."
-	@CURRENT_COUNT=$$(aws ecs describe-services --cluster kishax-infrastructure-cluster --services kishax-gather-bot-service-v2 --profile $(AWS_PROFILE) --query "services[0].desiredCount" --output text); \
-	if [ "$$CURRENT_COUNT" = "0" ]; then \
-		aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-gather-bot-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Gather Botサービスを開始しました"; \
-	else \
-		echo "ℹ️ Gather Botサービスは既に実行中です (desired-count=$$CURRENT_COUNT)"; \
-	fi
+	@scripts/ecs-service.sh start kishax-gather-bot-service-v2
 
 .PHONY: start-web
 start-web: ## Web停止中サービスを開始
-	@echo "▶️ Webサービスを開始中..."
-	@CURRENT_COUNT=$$(aws ecs describe-services --cluster kishax-infrastructure-cluster --services kishax-web-service-v2 --profile $(AWS_PROFILE) --query "services[0].desiredCount" --output text); \
-	if [ "$$CURRENT_COUNT" = "0" ]; then \
-		aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-web-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Webサービスを開始しました"; \
-	else \
-		echo "ℹ️ Webサービスは既に実行中です (desired-count=$$CURRENT_COUNT)"; \
-	fi
+	@scripts/ecs-service.sh start kishax-web-service-v2
 
 .PHONY: start-auth
 start-auth: ## Auth停止中サービスを開始
-	@echo "▶️ Authサービスを開始中..."
-	@CURRENT_COUNT=$$(aws ecs describe-services --cluster kishax-infrastructure-cluster --services kishax-auth-service-v2 --profile $(AWS_PROFILE) --query "services[0].desiredCount" --output text); \
-	if [ "$$CURRENT_COUNT" = "0" ]; then \
-		aws ecs update-service --cluster kishax-infrastructure-cluster --service kishax-auth-service-v2 --desired-count 1 --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Authサービスを開始しました"; \
-	else \
-		echo "ℹ️ Authサービスは既に実行中です (desired-count=$$CURRENT_COUNT)"; \
-	fi
+	@scripts/ecs-service.sh start kishax-auth-service-v2
 
 .PHONY: start-all-services
 start-all-services: start-discord-bot start-gather-bot start-web start-auth ## 全停止中サービスを開始
@@ -310,47 +266,19 @@ start-all-services: start-discord-bot start-gather-bot start-web start-auth ## �
 
 .PHONY: stop-discord-bot
 stop-discord-bot: ## Discord Bot実行中タスクを即座に停止
-	@echo "⏹️ Discord Bot実行中タスクを即座停止中..."
-	@TASK_ARNS=$$(aws ecs list-tasks --cluster kishax-infrastructure-cluster --service kishax-discord-bot-service-v2 --profile $(AWS_PROFILE) --query "taskArns" --output text); \
-	if [ "$$TASK_ARNS" != "" ] && [ "$$TASK_ARNS" != "None" ]; then \
-		aws ecs stop-task --cluster kishax-infrastructure-cluster --task $$TASK_ARNS --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Discord Botタスクを停止しました"; \
-	else \
-		echo "ℹ️ Discord Botの実行中タスクはありません"; \
-	fi
+	@scripts/ecs-service.sh stop kishax-discord-bot-service-v2
 
 .PHONY: stop-gather-bot
 stop-gather-bot: ## Gather Bot実行中タスクを即座に停止
-	@echo "⏹️ Gather Bot実行中タスクを即座停止中..."
-	@TASK_ARNS=$$(aws ecs list-tasks --cluster kishax-infrastructure-cluster --service kishax-gather-bot-service-v2 --profile $(AWS_PROFILE) --query "taskArns" --output text); \
-	if [ "$$TASK_ARNS" != "" ] && [ "$$TASK_ARNS" != "None" ]; then \
-		aws ecs stop-task --cluster kishax-infrastructure-cluster --task $$TASK_ARNS --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Gather Botタスクを停止しました"; \
-	else \
-		echo "ℹ️ Gather Botの実行中タスクはありません"; \
-	fi
+	@scripts/ecs-service.sh stop kishax-gather-bot-service-v2
 
 .PHONY: stop-web
 stop-web: ## Web実行中タスクを即座に停止
-	@echo "⏹️ Web実行中タスクを即座停止中..."
-	@TASK_ARNS=$$(aws ecs list-tasks --cluster kishax-infrastructure-cluster --service kishax-web-service-v2 --profile $(AWS_PROFILE) --query "taskArns" --output text); \
-	if [ "$$TASK_ARNS" != "" ] && [ "$$TASK_ARNS" != "None" ]; then \
-		aws ecs stop-task --cluster kishax-infrastructure-cluster --task $$TASK_ARNS --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Webタスクを停止しました"; \
-	else \
-		echo "ℹ️ Webの実行中タスクはありません"; \
-	fi
+	@scripts/ecs-service.sh stop kishax-web-service-v2
 
 .PHONY: stop-auth
 stop-auth: ## Auth実行中タスクを即座に停止
-	@echo "⏹️ Auth実行中タスクを即座停止中..."
-	@TASK_ARNS=$$(aws ecs list-tasks --cluster kishax-infrastructure-cluster --service kishax-auth-service-v2 --profile $(AWS_PROFILE) --query "taskArns" --output text); \
-	if [ "$$TASK_ARNS" != "" ] && [ "$$TASK_ARNS" != "None" ]; then \
-		aws ecs stop-task --cluster kishax-infrastructure-cluster --task $$TASK_ARNS --profile $(AWS_PROFILE) > /dev/null; \
-		echo "✅ Authタスクを停止しました"; \
-	else \
-		echo "ℹ️ Authの実行中タスクはありません"; \
-	fi
+	@scripts/ecs-service.sh stop kishax-auth-service-v2
 
 .PHONY: stop-all-services
 stop-all-services: stop-discord-bot stop-gather-bot stop-web stop-auth ## 全実行中タスクを即座に停止
@@ -369,7 +297,7 @@ cancel-stack-update: ## CloudFormationスタック更新をキャンセル
 ## =============================================================================
 
 .PHONY: deploy-all
-deploy-all: deploy-lambda deploy-discord-bot deploy-gather-bot deploy-web deploy-auth ## 全サービスをデプロイ
+deploy-all: deploy-lambda deploy-discord-bot deploy-gather-bot deploy-web deploy-auth deploy-api ## 全サービスをデプロイ
 	@echo "✅ 全サービスのデプロイが完了しました"
 
 .PHONY: deploy-lambda
@@ -387,69 +315,23 @@ deploy-lambda: ## Lambda関数をデプロイ
 
 .PHONY: deploy-discord-bot
 deploy-discord-bot: ## Discord Botをデプロイ
-	@echo "🚀 Discord Botをデプロイ中..."
-	cd apps/discord-bot && \
-	docker buildx build --platform linux/amd64 -t kishax-discord-bot . && \
-	aws ecr get-login-password --region $(AWS_REGION) --profile $(AWS_PROFILE) | \
-		docker login --username AWS --password-stdin $(AWS_ECR_DISCORD_BOT) && \
-	docker tag kishax-discord-bot:latest $(AWS_ECR_DISCORD_BOT):latest && \
-	docker push $(AWS_ECR_DISCORD_BOT):latest && \
-	aws ecs update-service \
-		--cluster kishax-infrastructure-cluster \
-		--service kishax-discord-bot-service-v2 \
-		--force-new-deployment \
-		--profile $(AWS_PROFILE)
-	@echo "✅ Discord Botのデプロイが完了しました"
+	@scripts/docker-deploy.sh discord-bot $(AWS_ECR_DISCORD_BOT) kishax-infrastructure-cluster kishax-discord-bot-service-v2 $(AWS_PROFILE) $(AWS_REGION)
 
 .PHONY: deploy-gather-bot
 deploy-gather-bot: ## Gather Botをデプロイ
-	@echo "🚀 Gather Botをデプロイ中..."
-	cd apps/gather-bot && \
-	docker buildx build --platform linux/amd64 -t kishax-gather-bot . && \
-	aws ecr get-login-password --region $(AWS_REGION) --profile $(AWS_PROFILE) | \
-		docker login --username AWS --password-stdin $(AWS_ECR_GATHER_BOT) && \
-	docker tag kishax-gather-bot:latest $(AWS_ECR_GATHER_BOT):latest && \
-	docker push $(AWS_ECR_GATHER_BOT):latest && \
-	aws ecs update-service \
-		--cluster kishax-infrastructure-cluster \
-		--service kishax-gather-bot-service-v2 \
-		--force-new-deployment \
-		--profile $(AWS_PROFILE)
-	@echo "✅ Gather Botのデプロイが完了しました"
+	@scripts/docker-deploy.sh gather-bot $(AWS_ECR_GATHER_BOT) kishax-infrastructure-cluster kishax-gather-bot-service-v2 $(AWS_PROFILE) $(AWS_REGION)
 
 .PHONY: deploy-web
 deploy-web: ## Web アプリケーションをデプロイ
-	@echo "🚀 Web アプリケーションをデプロイ中..."
-	cd apps/web && \
-	npm install && \
-	npx prisma generate && \
-	docker buildx build --platform linux/amd64 -t kishax-web . && \
-	aws ecr get-login-password --region $(AWS_REGION) --profile $(AWS_PROFILE) | \
-		docker login --username AWS --password-stdin $(AWS_ECR_WEB) && \
-	docker tag kishax-web:latest $(AWS_ECR_WEB):latest && \
-	docker push $(AWS_ECR_WEB):latest && \
-	aws ecs update-service \
-		--cluster kishax-infrastructure-cluster \
-		--service kishax-web-service-v2 \
-		--force-new-deployment \
-		--profile $(AWS_PROFILE)
-	@echo "✅ Web アプリケーションのデプロイが完了しました"
+	@scripts/docker-deploy.sh web $(AWS_ECR_WEB) kishax-infrastructure-cluster kishax-web-service-v2 $(AWS_PROFILE) $(AWS_REGION)
 
 .PHONY: deploy-auth
 deploy-auth: ## Auth サービスをデプロイ
-	@echo "🚀 Auth サービスをデプロイ中..."
-	cd apps/auth && \
-	docker buildx build --platform linux/amd64 -t kishax-auth . && \
-	aws ecr get-login-password --region $(AWS_REGION) --profile $(AWS_PROFILE) | \
-		docker login --username AWS --password-stdin $(AWS_ECR_AUTH) && \
-	docker tag kishax-auth:latest $(AWS_ECR_AUTH):latest && \
-	docker push $(AWS_ECR_AUTH):latest
-	aws ecs update-service \
-		--cluster kishax-infrastructure-cluster \
-		--service kishax-auth-service-v2 \
-		--force-new-deployment \
-		--profile $(AWS_PROFILE)
-	@echo "✅ Auth サービスのデプロイが完了しました"
+	@scripts/docker-deploy.sh auth $(AWS_ECR_AUTH) kishax-infrastructure-cluster kishax-auth-service-v2 $(AWS_PROFILE) $(AWS_REGION)
+
+.PHONY: deploy-api
+deploy-api: ## API サービスをデプロイ
+	@scripts/docker-deploy.sh api $(AWS_ECR_AUTH) kishax-infrastructure-cluster kishax-api-service-v2 $(AWS_PROFILE) $(AWS_REGION)
 
 ## =============================================================================
 ## SAML・認証関連

--- a/aws/cloudformation-template.yaml
+++ b/aws/cloudformation-template.yaml
@@ -754,28 +754,10 @@ Resources:
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/email-pass"
             - Name: EMAIL_FROM
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/email-from"
-            - Name: MC_SOCKET_HOST
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/mc-socket-host"
-            - Name: MC_SOCKET_PORT
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/mc-socket-port"
-            - Name: MC_WEB_SQS_ACCESS_KEY_ID
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/mc-web-sqs-access-key-id"
-            - Name: MC_WEB_SQS_SECRET_ACCESS_KEY
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/mc-web-sqs-secret-access-key"
-            - Name: WEB_TO_MC_QUEUE_URL
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/web-to-mc-queue-url"
-            - Name: MC_TO_WEB_QUEUE_URL
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/mc-to-web-queue-url"
             - Name: REDIS_URL
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/redis-url"
-            - Name: WEB_API_URL
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/web-api-url"
-            - Name: WEB_API_KEY
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/web-api-key"
             - Name: INTERNAL_API_KEY
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/internal-api-key"
-            - Name: AUTH_API_KEY
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/auth-api-key"
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -1014,7 +996,7 @@ Resources:
 
             # SQS Worker Configuration
             - Name: QUEUE_MODE
-              Value: "MC"
+              Value: "WEB"
             - Name: SQS_WORKER_ENABLED
               Value: "true"
             - Name: SQS_WORKER_POLLING_INTERVAL_SECONDS
@@ -1026,17 +1008,9 @@ Resources:
             - Name: SQS_WORKER_VISIBILITY_TIMEOUT_SECONDS
               Value: "30"
 
-            # Web API Configuration (Internal ECS Network)
-            - Name: WEB_API_URL
-              Value: !Sub "http://${ApplicationLoadBalancer.DNSName}"
-            - Name: WEB_API_KEY
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/web-api-key"
-
             # Application Configuration
             - Name: APP_SHUTDOWN_GRACE_PERIOD_SECONDS
               Value: "30"
-            - Name: ENVIRONMENT
-              Value: production
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -1069,7 +1043,7 @@ Resources:
       ServiceName: kishax-api-service-v2
       Cluster: !Ref EcsCluster
       TaskDefinition: !Ref KishaxApiTaskDefinition
-      DesiredCount: 1
+      DesiredCount: 0 # 一時的に停止
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:
@@ -1201,7 +1175,7 @@ Resources:
       ServiceName: kishax-auth-service-v2
       Cluster: !Ref EcsCluster
       TaskDefinition: !Ref AuthTaskDefinition
-      DesiredCount: 1
+      DesiredCount: 0 # 一時的に停止
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:

--- a/aws/cloudformation-template.yaml
+++ b/aws/cloudformation-template.yaml
@@ -497,6 +497,11 @@ Resources:
           SourceSecurityGroupId: !Ref AlbSecurityGroup
           Description: Allow traffic from ALB to ECS tasks
         - IpProtocol: tcp
+          FromPort: 8080
+          ToPort: 8080
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+          Description: Allow traffic from ALB to Kishax API tasks
+        - IpProtocol: tcp
           FromPort: 9000
           ToPort: 9000
           SourceSecurityGroupId: !Ref AlbSecurityGroup
@@ -769,6 +774,8 @@ Resources:
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/web-api-key"
             - Name: INTERNAL_API_KEY
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/internal-api-key"
+            - Name: AUTH_API_KEY
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/auth-api-key"
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -905,6 +912,122 @@ Resources:
       Actions:
         - Type: forward
           TargetGroupArn: !Ref AuthTargetGroup
+
+  # ===========================================
+  # Kishax API ECS Resources
+  # ===========================================
+  KishaxApiTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: kishax-api-tg-v2
+      Port: 8080
+      Protocol: HTTP
+      TargetType: ip
+      VpcId: !Ref VpcId
+      HealthCheckPath: /api/health
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      Matcher:
+        HttpCode: 200
+      Tags:
+        - Key: Project
+          Value: Kishax
+        - Key: Component
+          Value: KishaxApi
+
+  KishaxApiListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      ListenerArn: !Ref HttpsListener
+      Priority: 50
+      Conditions:
+        - Field: host-header
+          Values:
+            - api.kishax.net
+        - Field: path-pattern
+          Values:
+            - /mc/auth/*
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref KishaxApiTargetGroup
+
+  KishaxApiTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: kishax-api-v2
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 512
+      Memory: 1024
+      ExecutionRoleArn: !GetAtt EcsTaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt EcsTaskRole.Arn
+      ContainerDefinitions:
+        - Name: kishax-api
+          Image: !Sub "${AccountId}.dkr.ecr.us-east-1.amazonaws.com/kishax-api:latest"
+          Essential: true
+          PortMappings:
+            - ContainerPort: 8080
+              Protocol: tcp
+          Environment:
+            - Name: DATABASE_URL
+              Value: "{{resolve:ssm:/kishax/web/database-url}}"
+            - Name: API_KEY
+              Value: "{{resolve:ssm:/kishax/api/api-key}}"
+            - Name: ENVIRONMENT
+              Value: production
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref KishaxApiLogGroup
+              awslogs-region: us-east-1
+              awslogs-stream-prefix: ecs
+      Tags:
+        - Key: Project
+          Value: Kishax
+        - Key: Component
+          Value: KishaxApi
+
+  KishaxApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/kishax-api-v2
+      RetentionInDays: 30
+      Tags:
+        - Key: Project
+          Value: Kishax
+        - Key: Component
+          Value: KishaxApi
+
+  KishaxApiService:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - KishaxApiTargetGroup
+      - KishaxApiListenerRule
+    Properties:
+      ServiceName: kishax-api-service-v2
+      Cluster: !Ref EcsCluster
+      TaskDefinition: !Ref KishaxApiTaskDefinition
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          SecurityGroups:
+            - !Ref EcsSecurityGroup
+          Subnets: !Ref PublicSubnetIds
+          AssignPublicIp: ENABLED
+      LoadBalancers:
+        - TargetGroupArn: !Ref KishaxApiTargetGroup
+          ContainerName: kishax-api
+          ContainerPort: 8080
+      HealthCheckGracePeriodSeconds: 120
+      Tags:
+        - Key: Project
+          Value: Kishax
+        - Key: Component
+          Value: KishaxApi
 
   # ===========================================
   # Auth ECS Resources (Keycloak)
@@ -1306,6 +1429,25 @@ Outputs:
     Value: !Ref GatherBotTaskDefinition
     Export:
       Name: !Sub "${AWS::StackName}-GatherBotTaskDefinitionArn"
+
+  # Kishax API ECS Outputs
+  KishaxApiServiceArn:
+    Description: Kishax API ECS Service ARN
+    Value: !Ref KishaxApiService
+    Export:
+      Name: !Sub "${AWS::StackName}-KishaxApiServiceArn"
+
+  KishaxApiTaskDefinitionArn:
+    Description: Kishax API Task Definition ARN
+    Value: !Ref KishaxApiTaskDefinition
+    Export:
+      Name: !Sub "${AWS::StackName}-KishaxApiTaskDefinitionArn"
+
+  KishaxApiTargetGroupArn:
+    Description: Kishax API Target Group ARN
+    Value: !Ref KishaxApiTargetGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-KishaxApiTargetGroupArn"
 
   # Discord Bot ECS Outputs
   DiscordBotServiceArn:

--- a/aws/cloudformation-template.yaml
+++ b/aws/cloudformation-template.yaml
@@ -966,23 +966,82 @@ Resources:
       TaskRoleArn: !GetAtt EcsTaskRole.Arn
       ContainerDefinitions:
         - Name: kishax-api
-          Image: !Sub "${AccountId}.dkr.ecr.us-east-1.amazonaws.com/kishax-api:latest"
+          Image: !Sub "${AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/kishax-api:latest"
           Essential: true
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp
           Environment:
+            # Multi-Module Configuration
+            - Name: SQS_BRIDGE_VERSION
+              Value: "1.0.4"
+            - Name: MC_AUTH_VERSION
+              Value: "1.0.4"
+            - Name: ENVIRONMENT
+              Value: "production"
+
+            # Authentication API Configuration
+            - Name: AUTH_API_ENABLED
+              Value: "true"
+            - Name: AUTH_API_PORT
+              Value: "8080"
+            - Name: AUTH_API_KEY
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/api/auth-api-key"
+
+            # Database Configuration
             - Name: DATABASE_URL
-              Value: "{{resolve:ssm:/kishax/web/database-url}}"
-            - Name: API_KEY
-              Value: "{{resolve:ssm:/kishax/api/api-key}}"
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/database-url"
+
+            # AWS SQS Configuration
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
+            - Name: MC_WEB_SQS_ACCESS_KEY_ID
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/api/sqs-access-key-id"
+            - Name: MC_WEB_SQS_SECRET_ACCESS_KEY
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/api/sqs-secret-access-key"
+            - Name: MC_TO_WEB_QUEUE_URL
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/mc-to-web-queue-url"
+            - Name: WEB_TO_MC_QUEUE_URL
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/web-to-mc-queue-url"
+
+            # Redis Configuration
+            - Name: REDIS_URL
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/redis-url"
+            - Name: REDIS_CONNECTION_TIMEOUT
+              Value: "5000"
+            - Name: REDIS_COMMAND_TIMEOUT
+              Value: "3000"
+
+            # SQS Worker Configuration
+            - Name: QUEUE_MODE
+              Value: "MC"
+            - Name: SQS_WORKER_ENABLED
+              Value: "true"
+            - Name: SQS_WORKER_POLLING_INTERVAL_SECONDS
+              Value: "5"
+            - Name: SQS_WORKER_MAX_MESSAGES
+              Value: "10"
+            - Name: SQS_WORKER_WAIT_TIME_SECONDS
+              Value: "20"
+            - Name: SQS_WORKER_VISIBILITY_TIMEOUT_SECONDS
+              Value: "30"
+
+            # Web API Configuration (Internal ECS Network)
+            - Name: WEB_API_URL
+              Value: !Sub "http://${ApplicationLoadBalancer.DNSName}"
+            - Name: WEB_API_KEY
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AccountId}:parameter/kishax/web/web-api-key"
+
+            # Application Configuration
+            - Name: APP_SHUTDOWN_GRACE_PERIOD_SECONDS
+              Value: "30"
             - Name: ENVIRONMENT
               Value: production
           LogConfiguration:
             LogDriver: awslogs
             Options:
               awslogs-group: !Ref KishaxApiLogGroup
-              awslogs-region: us-east-1
+              awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: ecs
       Tags:
         - Key: Project

--- a/aws/cloudformation-template.yaml
+++ b/aws/cloudformation-template.yaml
@@ -956,9 +956,9 @@ Resources:
           Environment:
             # Multi-Module Configuration
             - Name: SQS_BRIDGE_VERSION
-              Value: "1.0.4"
+              Value: "1.0.5"
             - Name: MC_AUTH_VERSION
-              Value: "1.0.4"
+              Value: "1.0.5"
             - Name: ENVIRONMENT
               Value: "production"
 

--- a/aws/ssm-parameters.json.example
+++ b/aws/ssm-parameters.json.example
@@ -120,16 +120,6 @@
     "Type": "SecureString"
   },
   {
-    "Name": "/kishax/web/mc-socket-host",
-    "Value": "YOUR_VALUE_HERE",
-    "Type": "SecureString"
-  },
-  {
-    "Name": "/kishax/web/mc-socket-port",
-    "Value": "YOUR_VALUE_HERE",
-    "Type": "SecureString"
-  },
-  {
     "Name": "/kishax/web/nextauth-secret",
     "Value": "YOUR_VALUE_HERE",
     "Type": "SecureString"
@@ -277,16 +267,6 @@
   {
     "Name": "/kishax/auth/aws-workmail-url",
     "Value": "https://yourorg.awsapps.com/mail",
-    "Type": "SecureString"
-  },
-  {
-    "Name": "/kishax/web/web-api-url",
-    "Value": "https://api.yourdomain.com",
-    "Type": "String"
-  },
-  {
-    "Name": "/kishax/web/web-api-key",
-    "Value": "YOUR_WEB_API_KEY",
     "Type": "SecureString"
   },
   {

--- a/scripts/docker-deploy.sh
+++ b/scripts/docker-deploy.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -e
+
+# Docker build & deploy用テンプレートスクリプト
+# 使用法: ./docker-deploy.sh <service> <ecr_repo> <cluster> <ecs_service> <profile> [region] [build_args]
+# service: サービス名 (discord-bot, gather-bot, web, auth, api)
+# ecr_repo: ECRリポジトリURL
+# cluster: ECSクラスター名
+# ecs_service: ECSサービス名
+# profile: AWS profile名
+# region: AWSリージョン (オプション)
+# build_args: Docker build時の追加引数 (オプション)
+
+SERVICE=$1
+ECR_REPO=$2
+CLUSTER=${3:-"kishax-infrastructure-cluster"}
+ECS_SERVICE=$4
+PROFILE=${5:-$AWS_PROFILE}
+REGION=${6:-$AWS_REGION}
+BUILD_ARGS=$7
+
+if [ -z "$SERVICE" ] || [ -z "$ECR_REPO" ] || [ -z "$ECS_SERVICE" ]; then
+  echo "Usage: $0 <service> <ecr_repo> <cluster> <ecs_service> <profile> [region] [build_args]"
+  exit 1
+fi
+
+echo "🚀 ${SERVICE}をデプロイ中..."
+
+# サービスディレクトリに移動
+if [ ! -d "apps/$SERVICE" ]; then
+  echo "❌ ディレクトリ apps/$SERVICE が見つかりません"
+  exit 1
+fi
+
+cd "apps/$SERVICE"
+
+# サービス固有の前処理
+case $SERVICE in
+"web")
+  echo "📦 Web アプリケーション用の前処理..."
+  npm install
+  npx prisma generate
+  ;;
+"api")
+  # API固有の処理があれば追加
+  ;;
+*)
+  # その他のサービスは特別な前処理なし
+  ;;
+esac
+
+# Docker build
+echo "🔨 Dockerイメージをビルド中..."
+if [ -n "$BUILD_ARGS" ]; then
+  docker buildx build --platform linux/amd64 $BUILD_ARGS -t "kishax-$SERVICE" .
+else
+  docker buildx build --platform linux/amd64 -t "kishax-$SERVICE" .
+fi
+
+# ECRログイン
+echo "🔑 ECRにログイン中..."
+aws ecr get-login-password --region "$REGION" --profile "$PROFILE" |
+  docker login --username AWS --password-stdin "$ECR_REPO"
+
+# Docker tag & push
+echo "📤 ECRにプッシュ中..."
+docker tag "kishax-$SERVICE:latest" "$ECR_REPO:latest"
+docker push "$ECR_REPO:latest"
+
+# ECSサービス更新
+echo "🔄 ECSサービスを更新中..."
+aws ecs update-service \
+  --cluster "$CLUSTER" \
+  --service "$ECS_SERVICE" \
+  --force-new-deployment \
+  --profile "$PROFILE" >/dev/null
+
+echo "✅ ${SERVICE}のデプロイが完了しました"
+
+# 元のディレクトリに戻る
+cd - >/dev/null
+

--- a/scripts/ecs-service.sh
+++ b/scripts/ecs-service.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -e
+
+# ECSサービス操作用テンプレートスクリプト
+# 使用法: ./ecs-service.sh <action> <service> <cluster> <profile> [count]
+# action: restart|enable|disable|start|stop
+# service: サービス名
+# cluster: クラスター名
+# profile: AWS profile名
+# count: desired-count (enable/disable/startで使用)
+
+ACTION=$1
+SERVICE=$2
+CLUSTER=${3:-"kishax-infrastructure-cluster"}
+PROFILE=${4:-$AWS_PROFILE}
+COUNT=${5:-1}
+
+if [ -z "$ACTION" ] || [ -z "$SERVICE" ]; then
+  echo "Usage: $0 <action> <service> [cluster] [profile] [count]"
+  echo "Actions: restart, enable, disable, start, stop"
+  exit 1
+fi
+
+case $ACTION in
+"restart")
+  echo "🔄 ${SERVICE}サービスを再起動中..."
+  aws ecs update-service \
+    --cluster "$CLUSTER" \
+    --service "$SERVICE" \
+    --force-new-deployment \
+    --profile "$PROFILE" >/dev/null
+  echo "✅ ${SERVICE}サービスの再起動を要求しました (新しいタスクで再開)"
+  ;;
+
+"enable")
+  echo "🟢 ${SERVICE}サービスを有効化中..."
+  aws ecs update-service \
+    --cluster "$CLUSTER" \
+    --service "$SERVICE" \
+    --desired-count "$COUNT" \
+    --profile "$PROFILE" >/dev/null
+  echo "✅ ${SERVICE}サービスを有効化しました"
+  ;;
+
+"disable")
+  echo "🔴 ${SERVICE}サービスを無効化中..."
+  aws ecs update-service \
+    --cluster "$CLUSTER" \
+    --service "$SERVICE" \
+    --desired-count 0 \
+    --profile "$PROFILE" >/dev/null
+  echo "✅ ${SERVICE}サービスを無効化しました"
+  ;;
+
+"start")
+  echo "▶️ ${SERVICE}サービスを開始中..."
+  CURRENT_COUNT=$(aws ecs describe-services \
+    --cluster "$CLUSTER" \
+    --services "$SERVICE" \
+    --profile "$PROFILE" \
+    --query "services[0].desiredCount" \
+    --output text)
+
+  if [ "$CURRENT_COUNT" = "0" ]; then
+    aws ecs update-service \
+      --cluster "$CLUSTER" \
+      --service "$SERVICE" \
+      --desired-count "$COUNT" \
+      --profile "$PROFILE" >/dev/null
+    echo "✅ ${SERVICE}サービスを開始しました"
+  else
+    echo "ℹ️ ${SERVICE}サービスは既に実行中です (desired-count=$CURRENT_COUNT)"
+  fi
+  ;;
+
+"stop")
+  echo "⏹️ ${SERVICE}実行中タスクを即座停止中..."
+  TASK_ARNS=$(aws ecs list-tasks \
+    --cluster "$CLUSTER" \
+    --service "$SERVICE" \
+    --profile "$PROFILE" \
+    --query "taskArns" \
+    --output text)
+
+  if [ "$TASK_ARNS" != "" ] && [ "$TASK_ARNS" != "None" ]; then
+    aws ecs stop-task \
+      --cluster "$CLUSTER" \
+      --task "$TASK_ARNS" \
+      --profile "$PROFILE" >/dev/null
+    echo "✅ ${SERVICE}タスクを停止しました"
+  else
+    echo "ℹ️ ${SERVICE}の実行中タスクはありません"
+  fi
+  ;;
+
+*)
+  echo "❌ 不正なアクション: $ACTION"
+  echo "使用可能なアクション: restart, enable, disable, start, stop"
+  exit 1
+  ;;
+esac
+


### PR DESCRIPTION
- Cloudformationでのkishax-apiのサービス・タスク定義
- WEBでは並列実行で動かさなくてよくなったため、ECS:WEBに渡す環境変数の整理
- Makefileの整理、スクリプトを使うことで分量を減らす
- SSMパラメータの整理